### PR TITLE
Added PublicKeyReader and fixed commented out specs

### DIFF
--- a/lib/ssh_keygen/provider.rb
+++ b/lib/ssh_keygen/provider.rb
@@ -71,6 +71,70 @@ module SSHKeygen
     end
   end
 
+  # Public SSH key Reader
+  # Based on http://stackoverflow.com/a/3162593/230526
+  # License: cc by-sa 3.0 - Jim Flood (http://stackoverflow.com/users/233596/jim-flood)
+  class PublicKeyReader
+    attr_reader :public_key, :type, :encoded, :comment
+
+    def initialize(public_key)
+      @public_key = public_key
+      @type, @encoded, @comment = public_key.split(' ')
+    end
+
+    def key
+      @key ||= begin
+        e, n = decode_key(encoded)
+        rsa = OpenSSL::PKey::RSA.new
+        rsa.e = e
+        rsa.n = n
+
+        rsa
+      end
+    end
+
+    # Fingerprint (SHA1 digest, colon delimited)
+    def key_fingerprint
+      OpenSSL::Digest::SHA1.hexdigest(key.to_der).scan(/../).join(':')
+    end
+
+    private
+
+    def read_length(decoded)
+      # four bytes, big-endian
+      decoded[0..3].unpack('N')[0]
+    end
+
+    def read_integer(decoded, length)
+      # shift all bytes into one integer
+      decoded[4..3 + length].unpack('C*').inject { |n, b| (n << 8) + b }
+    end
+
+    def cut(decoded, length)
+      decoded[4 + length..-1]
+    end
+
+    def decode_key(encoded_public_key)
+      # the second field is the Base64 piece needed
+      decoded = Base64.decode64(encoded_public_key)
+
+      # first field reading "ssh-rsa" is ignored
+      i = read_length(decoded)
+      decoded = cut(decoded, i)
+
+      # public exponent e
+      i = read_length(decoded)
+      e = read_integer(decoded, i)
+      decoded = cut(decoded, i)
+
+      # modulus n
+      i = read_length(decoded)
+      n = read_integer(decoded, i)
+
+      [e, n]
+    end
+  end
+
   # provider fucntions for the SSHKeygen Chef resoruce provider class
   module SSHKeygenProvider
     def create_key

--- a/test/spec/resources/ssh_keygen_spec.rb
+++ b/test/spec/resources/ssh_keygen_spec.rb
@@ -29,13 +29,13 @@ describe SSHKeygen::Generator do
       expect(key.ssh_public_key).to match(%r{^ssh-rsa [a-zA-Z0-9=/+]+ test@rspec})
     end
 
-    # it 'has a valid public key for the private key' do
-    #   generator_key_digest = key.key_fingerprint
-    #   public_key = key.ssh_public_key.split(' ')[1]
-    #   public_key_digest = create_fingerprint_from_key(Base64.strict_decode64(public_key))
-    #
-    #   expect(generator_key_digest).to eq(public_key_digest)
-    # end
+    it 'has a valid public key for the private key' do
+      generator_key_digest = key.key_fingerprint
+      public_key = key.ssh_public_key
+      public_key_digest = create_fingerprint_from_public_key(public_key)
+
+      expect(generator_key_digest).to eq(public_key_digest)
+    end
   end
 
   context 'with passphrase and a bit strength of 2048' do
@@ -52,13 +52,13 @@ describe SSHKeygen::Generator do
       expect(key.ssh_public_key).to match(%r{^ssh-rsa [a-zA-Z0-9=/+]+ test@rspec})
     end
 
-    # it 'has a valid public key for the private key' do
-    #   generator_key_digest = key.key_fingerprint
-    #   public_key = key.ssh_public_key.split(' ')[1]
-    #   public_key_digest = create_fingerprint_from_key(Base64.strict_decode64(public_key))
-    #
-    #   expect(generator_key_digest).to eq(public_key_digest)
-    # end
+    it 'has a valid public key for the private key' do
+      generator_key_digest = key.key_fingerprint
+      public_key = key.ssh_public_key
+      public_key_digest = create_fingerprint_from_public_key(public_key)
+
+      expect(generator_key_digest).to eq(public_key_digest)
+    end
   end
 end
 

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -15,10 +15,14 @@
 require 'poise_boiler/spec_helper'
 require 'ssh_keygen'
 
-# a small helper function that creates a SHA1 fingerprint from a private or
-# public key.
+# a small helper function that creates a SHA1 fingerprint from a private key
 def create_fingerprint_from_key(key, passphrase = nil)
   new_key = OpenSSL::PKey::RSA.new(key, passphrase)
   new_key_digest = OpenSSL::Digest::SHA1.new(new_key.public_key.to_der).to_s.scan(/../).join(':')
   new_key_digest
+end
+
+# a helper function that creates a SHA1 fingerprint from a public key
+def create_fingerprint_from_public_key(public_key)
+  ::SSHKeygen::PublicKeyReader.new(public_key).key_fingerprint
 end


### PR DESCRIPTION
This MR implements the "inverse" operation that deserializes a ssh key content back into `OpenSSL::PKey::RSA` so we can generate again the fingerprint from the public key instead of requiring the private key.